### PR TITLE
[Refactor/29] 방 알림 및 만료 기능 연동 

### DIFF
--- a/on-fe/app/globals.css
+++ b/on-fe/app/globals.css
@@ -11,3 +11,7 @@ html {
   overflow: hidden;
   font-size: 62.5%; /* 1rem = 10px */
 }
+
+.react-hot-toast {
+  z-index: 99999 !important;
+}

--- a/on-fe/components/metaverse/ChatInterface.jsx
+++ b/on-fe/components/metaverse/ChatInterface.jsx
@@ -48,7 +48,7 @@ export default function ChatInterface({ onSendMessage, messages = [], currentPla
             <div className="fixed bottom-[1rem] left-[2rem] z-50">
                 <button
                     onClick={toggleMinimize}
-                    className="bg-blue-600 hover:bg-blue-700 text-white px-[1.3rem] py-[1rem] rounded-lg shadow-lg transition duration-200 flex items-center"
+                    className="bg-yellow-400 hover:bg-yellow-700 px-[1.3rem] py-[1rem] rounded-lg shadow-lg transition duration-200 flex items-center"
                 >
                     <svg className="w-[2.5rem] h-[2.5rem] mr-[0.5rem]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
@@ -69,7 +69,7 @@ export default function ChatInterface({ onSendMessage, messages = [], currentPla
             {/* 채팅 헤더 */}
             <div className="flex items-center justify-between p-[1rem] border-b border-gray-600">
                 <div className="flex items-center">
-                    <svg className="w-[2rem] h-[2rem] text-blue-400 mr-[0.5rem]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-[2rem] h-[2rem] text-yellow-400 mr-[0.5rem]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
                     </svg>
                     <h3 className="text-white font-medium">채팅</h3>
@@ -103,17 +103,17 @@ export default function ChatInterface({ onSendMessage, messages = [], currentPla
                             <div
                                 className={`break-words whitespace-pre-wrap px-[1.5rem] py-[0.8rem] rounded-3xl ${
                                     msg.isOwn
-                                        ? 'bg-blue-600 text-white'
+                                        ? 'bg-white text-black-900'
                                         : 'bg-gray-700 text-gray-100'
                                 }`}
                             >
                                 {!msg.isOwn && (
-                                    <div className="text-xs text-blue-300 mb-[0.5rem]">
+                                    <div className="text-xs text-black-300 mb-[0.5rem]">
                                         {msg.playerName}
                                     </div>
                                 )}
                                 <div>{msg.text}</div>
-                                <div className={`text-base mt-[0.5rem] ${msg.isOwn ? 'text-blue-200' : 'text-gray-400'}`}>
+                                <div className={`text-base mt-[0.5rem] ${msg.isOwn ? 'text-black-200' : 'text-gray-400'}`}>
                                     {msg.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                                 </div>
                             </div>
@@ -132,20 +132,20 @@ export default function ChatInterface({ onSendMessage, messages = [], currentPla
                         onChange={(e) => setMessage(e.target.value)}
                         onKeyPress={handleKeyPress}
                         placeholder="메시지를 입력하세요..."
-                        className="flex-1 bg-gray-700 text-white placeholder-gray-400 p-[1rem] rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                        className="flex-1 bg-gray-900/50 text-white placeholder-white-400 p-[1rem] rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-400"
                         maxLength={200}
                     />
                     <button
                         onClick={handleSendMessage}
                         disabled={!message.trim()}
-                        className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white px-4 py-2 rounded-md transition duration-200"
+                        className="bg-yellow-400 hover:bg-yellow-700 disabled:bg-yellow-900/50 disabled:cursor-not-allowed disabled:text-white/50 text-yellow-900 px-4 py-2 rounded-md transition duration-200"
                     >
                         <svg className="w-[2rem] h-[2rem]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
                         </svg>
                     </button>
                 </div>
-                <div className="text-base text-gray-400 mt-1">
+                <div className="text-base text-white mt-1">
                     Enter로 전송 • 최대 200자
                 </div>
             </div>

--- a/on-fe/components/metaverse/MetaverseContainer.jsx
+++ b/on-fe/components/metaverse/MetaverseContainer.jsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { MetaverseProvider } from '../../contexts/MetaverseContext';
+import { useEffect } from 'react';
+import { toast } from 'react-hot-toast';
+import { MetaverseProvider, useMetaverseContext } from '../../contexts/MetaverseContext';
 import useMetaverse from '../../hooks/useMetaverse';
 import usePhaserGame from '../../hooks/usePhaserGame';
 import MetaverseGameView from './MetaverseGameView';
 import FlyingStar from '../background/FlyingStar';
 import LoadingSpinner from '../loading/LoadingSpinner';
+import AlertModal from '../modal/AlertModal';
 
 function MetaverseContent({ userId, userNickname, roomId }) {
     const metaverse = useMetaverse(userId, userNickname, roomId);
+    const { state, actions } = useMetaverseContext();
     const phaserGame = usePhaserGame(
         metaverse.userId,
         metaverse.playerName,
@@ -23,6 +27,37 @@ function MetaverseContent({ userId, userNickname, roomId }) {
             metaverse.setGameReady(true);
         }
     );
+
+    // 방 10분 알람 토스트 표시
+    useEffect(() => {
+        if (state.roomNotification) {
+            toast.success('🔔 ' + state.roomNotification.message, {
+                duration: 6000,
+                position: 'top-center',
+                style: {
+                    fontSize: '16px',
+                    padding: '20px',
+                    backgroundColor: '#FF8C00',
+                    color: 'white',
+                    fontWeight: 'bold'
+                }
+            });
+            
+            // 토스트 표시 후 상태 초기화
+            const timer = setTimeout(() => {
+                actions.clearRoomNotification();
+            }, 6100);
+            
+            return () => clearTimeout(timer);
+        }
+    }, [state.roomNotification, actions]);
+
+    // 방 만료 시 AlertModal 표시
+    const handleRoomExpiredConfirm = () => {
+        actions.setRoomExpired(false);
+        // 방 목록 페이지로 이동
+        window.location.href = '/room';
+    };
 
     // STOMP 연결 중이면 연결 대기 화면 표시
     if (!metaverse.isConnected) {
@@ -43,22 +78,42 @@ function MetaverseContent({ userId, userNickname, roomId }) {
                         </button>
                     )}
                 </div>
+
+                {/* 방 만료 AlertModal */}
+                <AlertModal
+                    open={state.roomExpired}
+                    title="방이 만료되었습니다"
+                    description="학습 시간이 종료되어 방을 퇴장합니다."
+                    confirmText="확인"
+                    onConfirm={handleRoomExpiredConfirm}
+                />
             </div>
         );
     }
 
     // STOMP 연결 완료 후 게임 뷰 표시
     return (
-        <MetaverseGameView
-            gameContainerRef={phaserGame.gameContainerRef}
-            onlineCount={metaverse.onlineCount}
-            playerName={metaverse.player?.name || metaverse.playerName}
-            messages={metaverse.chatMessages}
-            onSendMessage={metaverse.sendChatMessage}
-            userId={metaverse.userId}
-            // TODO: 방 이름 전달 metaverse에 roomName이 없으면 roomId 사용
-            roomName={metaverse.roomName || "학습 공간 (추후 방 이름)"}
-        />
+        <>
+            <MetaverseGameView
+                gameContainerRef={phaserGame.gameContainerRef}
+                onlineCount={metaverse.onlineCount}
+                playerName={metaverse.player?.name || metaverse.playerName}
+                messages={metaverse.chatMessages}
+                onSendMessage={metaverse.sendChatMessage}
+                userId={metaverse.userId}
+                // TODO: 방 이름 전달 metaverse에 roomName이 없으면 roomId 사용
+                roomName={metaverse.roomName || "학습 공간 (추후 방 이름)"}
+            />
+
+            {/* 방 만료 AlertModal */}
+            <AlertModal
+                open={state.roomExpired}
+                title="방이 만료되었습니다"
+                description="학습 시간이 종료되어 방을 퇴장합니다."
+                confirmText="확인"
+                onConfirm={handleRoomExpiredConfirm}
+            />
+        </>
     );
 }
 

--- a/on-fe/components/metaverse/MetaverseContainer.jsx
+++ b/on-fe/components/metaverse/MetaverseContainer.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { toast } from 'react-hot-toast';
 import { MetaverseProvider, useMetaverseContext } from '../../contexts/MetaverseContext';
@@ -11,6 +12,7 @@ import LoadingSpinner from '../loading/LoadingSpinner';
 import AlertModal from '../modal/AlertModal';
 
 function MetaverseContent({ userId, userNickname, roomId }) {
+    const router = useRouter();
     const metaverse = useMetaverse(userId, userNickname, roomId);
     const { state, actions } = useMetaverseContext();
     const phaserGame = usePhaserGame(
@@ -56,56 +58,44 @@ function MetaverseContent({ userId, userNickname, roomId }) {
     const handleRoomExpiredConfirm = () => {
         actions.setRoomExpired(false);
         // 방 목록 페이지로 이동
-        window.location.href = '/room';
+        router.push('/room');
     };
 
-    // STOMP 연결 중이면 연결 대기 화면 표시
-    if (!metaverse.isConnected) {
-        return (
-            <div className="relative flex items-center justify-center w-full h-screen bg-black overflow-hidden">
-                <FlyingStar />
-                <div className="relative z-10 bg-black bg-opacity-50 backdrop-blur-sm border border-white border-opacity-20 rounded-xl p-8 text-center">
-                    <LoadingSpinner message='메타버스에 연결 중..' color='white'/>
-                    <p className="text-gray-300 mt-4">
-                        {metaverse.error ? `연결 오류: ${metaverse.error}` : '잠시만 기다려주세요'}
-                    </p>
-                    {metaverse.error && (
-                        <button
-                            onClick={metaverse.connect}
-                            className="mt-4 px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition duration-200"
-                        >
-                            다시 연결
-                        </button>
-                    )}
-                </div>
-
-                {/* 방 만료 AlertModal */}
-                <AlertModal
-                    open={state.roomExpired}
-                    title="방이 만료되었습니다"
-                    description="학습 시간이 종료되어 방을 퇴장합니다."
-                    confirmText="확인"
-                    onConfirm={handleRoomExpiredConfirm}
-                />
-            </div>
-        );
-    }
-
-    // STOMP 연결 완료 후 게임 뷰 표시
+    // STOMP 연결 여부에 따른 조건부 렌더링
     return (
         <>
-            <MetaverseGameView
-                gameContainerRef={phaserGame.gameContainerRef}
-                onlineCount={metaverse.onlineCount}
-                playerName={metaverse.player?.name || metaverse.playerName}
-                messages={metaverse.chatMessages}
-                onSendMessage={metaverse.sendChatMessage}
-                userId={metaverse.userId}
-                // TODO: 방 이름 전달 metaverse에 roomName이 없으면 roomId 사용
-                roomName={metaverse.roomName || "학습 공간 (추후 방 이름)"}
-            />
+            {!metaverse.isConnected ? (
+                <div className="relative flex items-center justify-center w-full h-screen bg-black overflow-hidden">
+                    <FlyingStar />
+                    <div className="relative z-10 bg-black bg-opacity-50 backdrop-blur-sm border border-white border-opacity-20 rounded-xl p-8 text-center">
+                        <LoadingSpinner message='메타버스에 연결 중..' color='white'/>
+                        <p className="text-gray-300 mt-4">
+                            {metaverse.error ? `연결 오류: ${metaverse.error}` : '잠시만 기다려주세요'}
+                        </p>
+                        {metaverse.error && (
+                            <button
+                                onClick={metaverse.connect}
+                                className="mt-4 px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition duration-200"
+                            >
+                                다시 연결
+                            </button>
+                        )}
+                    </div>
+                </div>
+            ) : (
+                <MetaverseGameView
+                    gameContainerRef={phaserGame.gameContainerRef}
+                    onlineCount={metaverse.onlineCount}
+                    playerName={metaverse.player?.name || metaverse.playerName}
+                    messages={metaverse.chatMessages}
+                    onSendMessage={metaverse.sendChatMessage}
+                    userId={metaverse.userId}
+                    // TODO: 방 이름 전달 metaverse에 roomName이 없으면 roomId 사용
+                    roomName={metaverse.roomName || "학습 공간 (추후 방 이름)"}
+                />
+            )}
 
-            {/* 방 만료 AlertModal */}
+            {/* 방 만료 AlertModal (최상위 레벨에 한 번만 렌더링) */}
             <AlertModal
                 open={state.roomExpired}
                 title="방이 만료되었습니다"

--- a/on-fe/components/metaverse/MetaverseContainer.jsx
+++ b/on-fe/components/metaverse/MetaverseContainer.jsx
@@ -33,6 +33,7 @@ function MetaverseContent({ userId, userNickname, roomId }) {
     // 방 10분 알람 토스트 표시
     useEffect(() => {
         if (state.roomNotification) {
+            console.log('Room Notification:', state.roomNotification); // 디버깅용 로그, 필요시 제거
             toast.success('🔔 ' + state.roomNotification.message, {
                 duration: 6000,
                 position: 'top-center',

--- a/on-fe/components/metaverse/MetaverseContainer.jsx
+++ b/on-fe/components/metaverse/MetaverseContainer.jsx
@@ -33,7 +33,6 @@ function MetaverseContent({ userId, userNickname, roomId }) {
     // 방 10분 알람 토스트 표시
     useEffect(() => {
         if (state.roomNotification) {
-            console.log('Room Notification:', state.roomNotification); // 디버깅용 로그, 필요시 제거
             toast.success('🔔 ' + state.roomNotification.message, {
                 duration: 6000,
                 position: 'top-center',

--- a/on-fe/constants/API.js
+++ b/on-fe/constants/API.js
@@ -14,10 +14,26 @@ const WEBSOCKET = {
 }
 
 const METAVERSE = {
+    // Publish (클라이언트 → 서버)
     JOIN : (roomId) => `/app/room/${roomId}/join`,
-    PING : (roomId) => `/app/room/${roomId}.ping`,
-    MOVE : (roomId) => `/app/room/${roomId}.move`,
-    SYNC : (roomId) => `/app/room/${roomId}.sync`,
+    LEAVE : (roomId) => `/app/room/${roomId}/leave`,
+    MOVE : (roomId) => `/app/room/${roomId}/move`,
+    PING : (roomId) => `/app/room/${roomId}/ping`,
+    SYNC : (roomId) => `/app/room/${roomId}/sync`,
+    CHAT : (roomId) => `/app/room/${roomId}/chat`,
+    PLAYER_LEFT : "/app/playerLeft",
+    
+    // Subscribe (서버 → 클라이언트)
+    QUEUE_JOIN : "/user/queue/join",
+    QUEUE_POS_SNAPSHOT : "/user/queue/pos-snapshot",
+    QUEUE_MOVE_ACK : "/user/queue/move-ack",
+    TOPIC_POS : (roomId) => `/topic/room/${roomId}/pos`,
+    TOPIC_MSG : (roomId) => `/topic/room/${roomId}/msg`,
+    TOPIC_LEAVE : (roomId) => `/topic/room/${roomId}/leave`,
+    TOPIC_CHAT : (roomId) => `/topic/room/${roomId}/chat`,
+    TOPIC_NOTIFICATION : (roomId) => `/topic/room/${roomId}/notification`,
+    TOPIC_EXPIRATION : (roomId) => `/topic/room/${roomId}/expiration`,
+
 }
 
 const ROOM = {

--- a/on-fe/contexts/MetaverseContext.jsx
+++ b/on-fe/contexts/MetaverseContext.jsx
@@ -11,7 +11,9 @@ const initialState = {
     chatMessages: [],
     gameInstance: null,
     currentScene: null,
-    isGameReady: false
+    isGameReady: false,
+    roomNotification: null, // { message: string }
+    roomExpired: false
 };
 
 // 액션 타입
@@ -37,7 +39,12 @@ const ActionTypes = {
 
     // 에러 관련
     SET_ERROR: 'SET_ERROR',
-    CLEAR_ERROR: 'CLEAR_ERROR'
+    CLEAR_ERROR: 'CLEAR_ERROR',
+
+    // 방 알람 관련
+    SET_ROOM_NOTIFICATION: 'SET_ROOM_NOTIFICATION',
+    CLEAR_ROOM_NOTIFICATION: 'CLEAR_ROOM_NOTIFICATION',
+    SET_ROOM_EXPIRED: 'SET_ROOM_EXPIRED'
 };
 
 // 리듀서
@@ -136,6 +143,24 @@ const metaverseReducer = (state, action) => {
                 error: null
             };
 
+        case ActionTypes.SET_ROOM_NOTIFICATION:
+            return {
+                ...state,
+                roomNotification: action.payload
+            };
+
+        case ActionTypes.CLEAR_ROOM_NOTIFICATION:
+            return {
+                ...state,
+                roomNotification: null
+            };
+
+        case ActionTypes.SET_ROOM_EXPIRED:
+            return {
+                ...state,
+                roomExpired: action.payload
+            };
+
         default:
             return state;
     }
@@ -206,7 +231,20 @@ export const MetaverseProvider = ({ children }) => {
             payload: error 
         }),
 
-        clearError: () => dispatch({ type: ActionTypes.CLEAR_ERROR })
+        clearError: () => dispatch({ type: ActionTypes.CLEAR_ERROR }),
+
+        // 방 알람 관련 액션
+        setRoomNotification: (notification) => dispatch({ 
+            type: ActionTypes.SET_ROOM_NOTIFICATION, 
+            payload: notification 
+        }),
+
+        clearRoomNotification: () => dispatch({ type: ActionTypes.CLEAR_ROOM_NOTIFICATION }),
+
+        setRoomExpired: (expired) => dispatch({ 
+            type: ActionTypes.SET_ROOM_EXPIRED, 
+            payload: expired 
+        })
     }), []);
 
     const value = useMemo(() => ({

--- a/on-fe/hooks/useMetaverse.jsx
+++ b/on-fe/hooks/useMetaverse.jsx
@@ -71,6 +71,16 @@ export default function useMetaverse(userId, userNickname, roomId) {
                 router.push('/room');
             });
 
+            // 방 알람 콜백 등록
+            metaverseService.setRoomNotificationCallback((notification) => {
+                actions.setRoomNotification(notification);
+            });
+
+            // 방 만료 콜백 등록
+            metaverseService.setRoomExpirationCallback(() => {
+                actions.setRoomExpired(true);
+            });
+
             // 플레이어 데이터 설정
             const playerData = {
                 id: userIdRef.current,

--- a/on-fe/hooks/user/useUserInfo.jsx
+++ b/on-fe/hooks/user/useUserInfo.jsx
@@ -1,27 +1,24 @@
 import { userService } from '@/apis/client/userService';
 import { isLoggedIn } from '@/util/AuthUtil';
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
+import { useUserStore } from '@/stores/userStore';
 
 const useUserInfo = () => {
-    const [userInfo, setUserInfo] = useState({ memberId: null, nickname: null });
+    const memberId = useUserStore(state => state.memberId);
+    const nickname = useUserStore(state => state.nickname);   
+    const status = useUserStore(state => state.status);
+    const fetchUser = useUserStore(state => state.fetchUser);
 
     useEffect(() => {
-        const fetchUserInfo = async () => {
-            try {
-                const response = await userService.getMyInfo();
-                const { memberId, nickname } = response;
-                setUserInfo({ memberId: memberId, nickname: nickname });
-            } catch(e){
-                console.error("[useUserInfo] 조회 오류 : ", e);
-                setUserInfo({memberId : null, nickname : null});
-            }
-        }
-        if(isLoggedIn()) {
-            fetchUserInfo();
-        }
-    }, []);
+    if (status === 'idle' || status === 'error') {
+      fetchUser();
+    }
+  }, [status, fetchUser]);
 
-    return userInfo;
+    return {
+    memberId,
+    nickname
+  };
 }
 
 export default useUserInfo

--- a/on-fe/hooks/user/useUserInfo.jsx
+++ b/on-fe/hooks/user/useUserInfo.jsx
@@ -1,4 +1,3 @@
-import { userService } from '@/apis/client/userService';
 import { isLoggedIn } from '@/util/AuthUtil';
 import { useEffect } from 'react';
 import { useUserStore } from '@/stores/userStore';
@@ -10,7 +9,7 @@ const useUserInfo = () => {
     const fetchUser = useUserStore(state => state.fetchUser);
 
     useEffect(() => {
-    if (status === 'idle' || status === 'error') {
+    if (isLoggedIn() && (status === 'idle' || status === 'error')) {
       fetchUser();
     }
   }, [status, fetchUser]);

--- a/on-fe/phaser/game/main.js
+++ b/on-fe/phaser/game/main.js
@@ -31,7 +31,10 @@ const createConfig = (Phaser) => {
         scene: [
             BootScene,
             MetaverseScene
-        ]
+        ],
+        audio: {
+          disableWebAudio: true
+        }
     };
 };
 

--- a/on-fe/phaser/game/main.js
+++ b/on-fe/phaser/game/main.js
@@ -1,6 +1,5 @@
 import { BootScene } from './scenes/BootScene';
 import { MetaverseScene } from './scenes/MetaverseScene';
-import { getOptimalSize } from '@/phaser/game/util/gameUtil';
 
 // Dynamic import for Phaser to avoid SSR issues
 const getPhaser = () => {
@@ -12,22 +11,15 @@ const getPhaser = () => {
 
 // Dynamic config creation to avoid SSR issues
 const createConfig = (Phaser) => {
-    const { width, height } = getOptimalSize();
     
     return {
         type: Phaser.AUTO,
-        width,
-        height,
         parent: 'game-container',
         backgroundColor: '#028af8',
         scale: {
-            // mode: Phaser.Scale.FIT,
-            // autoCenter: Phaser.Scale.CENTER_BOTH,
             // RESIZE로 변경함으로써 반응형 지원
             mode: Phaser.Scale.RESIZE,
             parent: 'game-container',
-            width,
-            height
         },
         physics: {
             default: 'arcade',

--- a/on-fe/services/metaverseService.js
+++ b/on-fe/services/metaverseService.js
@@ -20,6 +20,8 @@ class MetaverseService {
         this.onlineCountCallback = null;
         this.chatMessageCallback = null;
         this.errorCallback = null;
+        this.roomNotificationCallback = null;
+        this.roomExpirationCallback = null;
         this.currentRoomId = null;
         this.joinStatus = null;
         this.sequenceNumber = 0;
@@ -422,6 +424,13 @@ class MetaverseService {
     // 방 종료 10분전 알람 처리
     _handleRoomNotification(notificationData) {
         try {
+            // UI 콜백 호출 (toast 표시)
+            if (this.roomNotificationCallback) {
+                this.roomNotificationCallback({
+                    message: '방이 10분 후 종료됩니다'
+                });
+            }
+
             if (GameEventBus && typeof GameEventBus.showRoomNotification === 'function') {
                 GameEventBus.showRoomNotification(notificationData);
             }
@@ -435,6 +444,11 @@ class MetaverseService {
     // 방 종료 알람 처리
     _handleRoomExpiration(expirationData) {
         try {
+            // UI 콜백 호출 (AlertModal 표시)
+            if (this.roomExpirationCallback) {
+                this.roomExpirationCallback();
+            }
+
             if (GameEventBus && typeof GameEventBus.showRoomExpiration === 'function') {
                 GameEventBus.showRoomExpiration(expirationData);
             }
@@ -650,11 +664,21 @@ class MetaverseService {
         this.errorCallback = callback;
     }
 
+    setRoomNotificationCallback(callback) {
+        this.roomNotificationCallback = callback;
+    }
+
+    setRoomExpirationCallback(callback) {
+        this.roomExpirationCallback = callback;
+    }
+
     // UI 콜백 해제 메서드
     clearUICallbacks() {
         this.onlineCountCallback = null;
         this.chatMessageCallback = null;
         this.errorCallback = null;
+        this.roomNotificationCallback = null;
+        this.roomExpirationCallback = null;
     }
 
     _updateOnlineCount(count) {

--- a/on-fe/services/metaverseService.js
+++ b/on-fe/services/metaverseService.js
@@ -427,7 +427,7 @@ class MetaverseService {
             // UI 콜백 호출 (toast 표시)
             if (this.roomNotificationCallback) {
                 this.roomNotificationCallback({
-                    message: '방이 10분 후 종료됩니다'
+                    message: notificationData.message || '방이 10분 후 종료됩니다'
                 });
             }
 

--- a/on-fe/stores/userStore.js
+++ b/on-fe/stores/userStore.js
@@ -1,14 +1,18 @@
 import { create } from 'zustand';
 import { userService } from '@/apis/client/userService';
 
-export const useUserStore = create((set, get) => ({
-  // 상태
+const initialState = {
   memberId: null,
   nickname: '',
   avatar: 0,
   loginStatus: false,
   status: 'idle', // idle | loading | ready | error
+};
 
+export const useUserStore = create((set, get) => ({
+  // 상태
+  ...initialState,
+  
   // 액션
   fetchUser: async () => {
     const { status } = get();


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #57 
closed #59 

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)

### 📌 주요 변경사항

#### 1️⃣ **전역 상태 관리 리팩토링**
- `useUserInfo` 훅을 Zustand 기반 `useUserStore`로 마이그레이션
- 중복된 API 호출 제거 및 단일 데이터 소스 원칙 준수
- `userStore.js`에 `initialState` 상수 추출로 코드 가독성 개선

#### 2️⃣ **메타버스 방 알람 시스템 구현**
- **Context 확장**: `roomNotification`, `roomExpired` 상태 추가
- **UI 구현**: 
  - 10분 알람 시 `react-hot-toast`로 orange 배경 toast 자동 표시 (6초)
  - 방 만료 시 `AlertModal`로 사용자 안내 후 자동 리다이렉트
- **서비스 통합**: 
  - `metaverseService`에 콜백 메서드 추가 (`setRoomNotificationCallback`, `setRoomExpirationCallback`)
  - 백엔드 STOMP 이벤트와 React UI의 연동

#### 3️⃣ **메타버스 소켓 엔드포인트 상수화**
- 반복되는 엔드포인트 문자열을 상수로 정의하여 유지보수성 향상 `API.js`

#### 4️⃣ **채팅창 UI 변경**
- 기존 파란색에서 전체적인 이미지(노란색)에 맞춰 통일화

#### 🚨**AudioContext suspend 오류 방지를 위해 WebAudio 비활성화**
- Phaser 기본 WebAudio 사용 시 SPA 환경에서 AudioContext suspend/resume 오류 발생
- WebAudio 비활성화를 통해 브라우저 visibility change 시 에러 원천 차단
- 추후 사운드 기능 도입 시 lifecycle 정비 후 재활성화 예정


### 📊 변경 파일 (4개)
- `contexts/MetaverseContext.jsx` - 방 알람 상태 및 액션 추가
- `components/metaverse/MetaverseContainer.jsx` - Toast/AlertModal UI 구현
- `services/metaverseService.js` - 콜백 메서드 및 이벤트 핸들러 추가
- `hooks/useMetaverse.jsx` - 콜백 등록 및 상태 연동

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] 방 만료 시간 카운트다운 UI 추가 (향후 개선)
- [ ] 방 이름 UI 추가 (향후 개선)

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
- **useUserInfo 리팩토링**: 기존 훅과 동일한 반환값 구조(`{ memberId, nickname }`)를 유지하므로 컴포넌트 수정 불필요
- **방 알람 시스템**: 백엔드에서 STOMP 토픽(`TOPIC_NOTIFICATION`, `TOPIC_EXPIRATION`)으로 이벤트 전송 시 자동으로 UI에 반영됨
- **git 커밋 분리**: 로직별로 4개 커밋으로 분리되어 있어 이력 추적 용이
- 머지 대상: **develop 브랜치** ⭕

### Images 📸

<img width="1344" height="918" alt="스크린샷 2026-01-23 11 52 30" src="https://github.com/user-attachments/assets/a102cf16-421b-410d-a620-73eacaf6234f" />
